### PR TITLE
Move patches into this repo to remove the old REE fork

### DIFF
--- a/patches/34ba44f94a62c63ddf02a045b6f4edcd6eab4989.patch
+++ b/patches/34ba44f94a62c63ddf02a045b6f4edcd6eab4989.patch
@@ -1,0 +1,129 @@
+From 34ba44f94a62c63ddf02a045b6f4edcd6eab4989 Mon Sep 17 00:00:00 2001
+From: nagachika <nagachika@b2dd03c8-39d4-4d8f-98ff-823fe69b080e>
+Date: Fri, 22 Nov 2013 04:00:39 +0000
+Subject: [PATCH] cherry pick 46cd2f4 for CVE-2013-4164
+
+merge revision(s) 43775:
+
+	* util.c (ruby_strtod): ignore too long fraction part, which does not
+	  affect the result.
+
+git-svn-id: svn+ssh://ci.ruby-lang.org/ruby/branches/ruby_2_0_0@43778 b2dd03c8-39d4-4d8f-98ff-823fe69b080e
+
+Conflicts:
+	ChangeLog
+	test/ruby/test_float.rb
+	version.h
+---
+ ChangeLog               |  5 +++++
+ test/ruby/test_float.rb |  6 ++++++
+ util.c                  | 14 ++++++++++++--
+ version.h               | 10 +++++-----
+ 4 files changed, 28 insertions(+), 7 deletions(-)
+
+diff --git a/ChangeLog b/ChangeLog
+index a09237e..e37c7e0 100644
+--- a/ChangeLog
++++ b/ChangeLog
+@@ -1,3 +1,8 @@
++Fri Nov 22 12:46:08 2013  Nobuyoshi Nakada  <nobu@ruby-lang.org>
++
++	* util.c (ruby_strtod): ignore too long fraction part, which does not
++	  affect the result.
++
+ Wed Feb  8 14:06:59 2012  Hiroshi Nakamura  <nahi@ruby-lang.org>
+ 
+ 	* ext/openssl/ossl_ssl.c: Add SSL constants and allow to unset SSL
+diff --git a/test/ruby/test_float.rb b/test/ruby/test_float.rb
+index b6e643d..6daf061 100644
+--- a/test/ruby/test_float.rb
++++ b/test/ruby/test_float.rb
+@@ -171,4 +171,10 @@ def test_cmp
+     assert_raise(ArgumentError) { 1.0 < nil }
+     assert_raise(ArgumentError) { 1.0 <= nil }
+   end
++
++  def test_long_string
++    assert_separately([], <<-'end;')
++    assert_in_epsilon(10.0, ("1."+"1"*300000).to_f*9)
++    end;
++  end
+ end
+diff --git a/util.c b/util.c
+index 62f3368..e98efc6 100644
+--- a/util.c
++++ b/util.c
+@@ -892,6 +892,11 @@ extern void *MALLOC(size_t);
+ #else
+ #define MALLOC malloc
+ #endif
++#ifdef FREE
++extern void FREE(void*);
++#else
++#define FREE free
++#endif
+ 
+ #ifndef Omit_Private_Memory
+ #ifndef PRIVATE_MEM
+@@ -1176,7 +1181,7 @@ Balloc(int k)
+ #endif
+ 
+     ACQUIRE_DTOA_LOCK(0);
+-    if ((rv = freelist[k]) != 0) {
++    if (k <= Kmax && (rv = freelist[k]) != 0) {
+         freelist[k] = rv->next;
+     }
+     else {
+@@ -1186,7 +1191,7 @@ Balloc(int k)
+ #else
+         len = (sizeof(Bigint) + (x-1)*sizeof(ULong) + sizeof(double) - 1)
+                 /sizeof(double);
+-        if (pmem_next - private_mem + len <= PRIVATE_mem) {
++        if (k <= Kmax && pmem_next - private_mem + len <= PRIVATE_mem) {
+             rv = (Bigint*)pmem_next;
+             pmem_next += len;
+         }
+@@ -1205,6 +1210,10 @@ static void
+ Bfree(Bigint *v)
+ {
+     if (v) {
++        if (v->k > Kmax) {
++            FREE(v);
++            return;
++        }
+         ACQUIRE_DTOA_LOCK(0);
+         v->next = freelist[v->k];
+         freelist[v->k] = v;
+@@ -2200,6 +2209,7 @@ ruby_strtod(const char *s00, char **se)
+         for (; c >= '0' && c <= '9'; c = *++s) {
+ have_dig:
+             nz++;
++            if (nf > DBL_DIG * 2) continue;
+             if (c -= '0') {
+                 nf += nz;
+                 for (i = 1; i < nz; i++)
+diff --git a/version.h b/version.h
+index d6f16f5..6773217 100644
+--- a/version.h
++++ b/version.h
+@@ -1,15 +1,15 @@
+ #define RUBY_VERSION "1.8.7"
+-#define RUBY_RELEASE_DATE "2012-02-08"
++#define RUBY_RELEASE_DATE "2013-11-26"
+ #define RUBY_VERSION_CODE 187
+-#define RUBY_RELEASE_CODE 20120208
+-#define RUBY_PATCHLEVEL 358
++#define RUBY_RELEASE_CODE 20131126
++#define RUBY_PATCHLEVEL 359
+ 
+ #define RUBY_VERSION_MAJOR 1
+ #define RUBY_VERSION_MINOR 8
+ #define RUBY_VERSION_TEENY 7
+ #define RUBY_RELEASE_YEAR 2012
+-#define RUBY_RELEASE_MONTH 2
+-#define RUBY_RELEASE_DAY 8
++#define RUBY_RELEASE_MONTH 11
++#define RUBY_RELEASE_DAY 26
+ 
+ #ifdef RUBY_EXTERN
+ RUBY_EXTERN const char ruby_version[];

--- a/patches/5384967a015be227e16af7a332a50d45e14ed0ad.patch
+++ b/patches/5384967a015be227e16af7a332a50d45e14ed0ad.patch
@@ -1,0 +1,39 @@
+From 5384967a015be227e16af7a332a50d45e14ed0ad Mon Sep 17 00:00:00 2001
+From: usa <usa@b2dd03c8-39d4-4d8f-98ff-823fe69b080e>
+Date: Fri, 22 Nov 2013 04:18:47 +0000
+Subject: [PATCH] merge revision(s) 43780:
+
+* util.c (ruby_strtod): BigMath requires more precision.
+
+git-svn-id: svn+ssh://ci.ruby-lang.org/ruby/branches/ruby_1_9_3@43782 b2dd03c8-39d4-4d8f-98ff-823fe69b080e
+---
+ util.c    | 2 +-
+ version.h | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/util.c b/util.c
+index e98efc6..54a1604 100644
+--- a/util.c
++++ b/util.c
+@@ -2209,7 +2209,7 @@ ruby_strtod(const char *s00, char **se)
+         for (; c >= '0' && c <= '9'; c = *++s) {
+ have_dig:
+             nz++;
+-            if (nf > DBL_DIG * 2) continue;
++            if (nf > DBL_DIG * 4) continue;
+             if (c -= '0') {
+                 nf += nz;
+                 for (i = 1; i < nz; i++)
+diff --git a/version.h b/version.h
+index 6773217..878532b 100644
+--- a/version.h
++++ b/version.h
+@@ -2,7 +2,7 @@
+ #define RUBY_RELEASE_DATE "2013-11-26"
+ #define RUBY_VERSION_CODE 187
+ #define RUBY_RELEASE_CODE 20131126
+-#define RUBY_PATCHLEVEL 359
++#define RUBY_PATCHLEVEL 360
+ 
+ #define RUBY_VERSION_MAJOR 1
+ #define RUBY_VERSION_MINOR 8

--- a/patches/tcmalloc_declare_memalign_volatile.patch
+++ b/patches/tcmalloc_declare_memalign_volatile.patch
@@ -1,0 +1,25 @@
+diff --git a/distro/google-perftools-1.7/src/tcmalloc.cc b/distro/google-perftools-1.7/src/tcmalloc.cc
+index 8d94d20..0769425 100644
+--- a/distro/google-perftools-1.7/src/tcmalloc.cc
++++ b/distro/google-perftools-1.7/src/tcmalloc.cc
+@@ -137,6 +137,13 @@
+ # define WIN32_DO_PATCHING 1
+ #endif
+ 
++// GLibc 2.14+ requires the hook functions be declared volatile, based on the value of the
++// define __MALLOC_HOOK_VOLATILE. For compatibility with older/non-GLibc implementations,
++// provide an empty definition.
++#if !defined(__MALLOC_HOOK_VOLATILE)
++#define __MALLOC_HOOK_VOLATILE
++#endif
++
+ using STL_NAMESPACE::max;
+ using STL_NAMESPACE::numeric_limits;
+ using STL_NAMESPACE::vector;
+@@ -1669,5 +1676,5 @@ static void *MemalignOverride(size_t align, size_t size, const void *caller)
+   MallocHook::InvokeNewHook(result, size);
+   return result;
+ }
+-void *(*__memalign_hook)(size_t, size_t, const void *) = MemalignOverride;
++void *(*__MALLOC_HOOK_VOLATILE __memalign_hook)(size_t, size_t, const void *) = MemalignOverride;
+ #endif  // #ifndef TCMALLOC_FOR_DEBUGALLOCATION


### PR DESCRIPTION
This wil remove the external dependency on the Genius fork of REE. Instead, it just vendors the three patches required to build the patched REE into this repo to simplify inter-repo dependencies. Once this gets merged, `build_ree.sh` will need to get updated to point to the master branch when it fetches the patches before applying them.

cc @outoftime @a-warner 
